### PR TITLE
Update documentation

### DIFF
--- a/src/commands/environment.js
+++ b/src/commands/environment.js
@@ -30,7 +30,7 @@ export default (cli, commandExecuter, outputFormatter, dockerCompose) => {
       .command('ssh [container]')
       .alias('connect')
       .option('-r, --root', 'Connect as ROOT')
-      .description('Connect to one of the docker service')
+      .description('Connect to one of the docker services')
       .action(async (container, options) => {
         outputFormatter.title('Connect to a container')
 
@@ -43,7 +43,7 @@ export default (cli, commandExecuter, outputFormatter, dockerCompose) => {
           const choice = await inquirer.prompt({
             type: 'list',
             name: 'container',
-            message: 'Select container to connect to',
+            message: 'Select a container to connect to:',
             choices: containers,
           })
 

--- a/src/commands/setup.js
+++ b/src/commands/setup.js
@@ -3,7 +3,7 @@ export default (cli, outputFormatter, dockerCompose, composer, npm) => {
   if (!cli._findCommand('setup')) {
     cli
       .command('setup')
-      .description('Initial Setup')
+      .description('Initial setup')
       .action(() => {
         outputFormatter.title('Project Setup')
 


### PR DESCRIPTION
Update README and documentation for clarity:

1. Remove quotes in the install command.
2. Remove `$` from Bash commands. GitHub adds a handy copy/paste button to code
   snippets but the `$` gets in the way when copying and pasting.
3. Re-write README from the point of view of fresh eyes (brand new dev to
   project); add any additional installation/configuration points to README
   documentation. Update for clarity.
4. Default commands: use backticks to let the user know that these are command
   line commands, not only headings, but actual commands/API.
5. Change the order of `setup` and `connect`. You can't connect if you are not
   already setup.