### PR TITLE
fix: only include subset of files in npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,13 @@
     "url": "https://github.com/aftdev/dev-env-manager"
   },
   "license": "MIT",
+  "files": [
+    "bin",
+    "docs",
+    "src",
+    "CHANGELOG.md",
+    "README.md"
+  ],
   "dependencies": {
     "awilix": "^6.0.0",
     "chalk": "^4.1.2",


### PR DESCRIPTION
Previously we did not have a "files" section in the package.json
file making it so ALL files were included in the npm package
This was totally unnecessary.
We are now only including the src folder, the changelog
and the docs files.