### PR TITLE
fix(ci): skip-ci on semantic-release

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -42,7 +42,7 @@
       "@semantic-release/git",
       {
         "assets": ["package.json", "CHANGELOG.md"],
-        "message": "chore(release): ${nextRelease.version}"
+        "message": "chore(release): ${nextRelease.version} [skip ci]"
       }
     ],
     "@semantic-release/github"


### PR DESCRIPTION
adding [skip ci] to the commit message will make it so
it does not trigger another build on the same branch

This was included in the default commit message by semantic-release
but removed by me by mistake/lack of understanding

Closes #28 